### PR TITLE
Nodejs version8 Compatible fix for crypto.pbkdf2Sync method

### DIFF
--- a/lib/ciphersuites.js
+++ b/lib/ciphersuites.js
@@ -66,7 +66,7 @@ function generateKey(password, salt, cipherId) {
     cipher.name
   );
   // */
-  var derivedKey = crypto.pbkdf2Sync(password, salt, iterations, cipher.keysize/8);
+  var derivedKey = crypto.pbkdf2Sync(password, salt, iterations, cipher.keysize/8, 'sha1');
   return derivedKey;
 }
 


### PR DESCRIPTION
In old version of NodeJS, crypto.pbkdf2Sync method does not mandatory requiring the digest parameter. Since nodejs 6, calling this method without the digest parameter would having a warning. Since nodejs 8, calling this method without the digest parameter would throw error which breaking some existing codes. For forward compatible concern, we should add the digest parameter which is the default value of 'sha1'.

#https://github.com/nodejs/node/pull/11305