### PR TITLE
Process Payload with same keys as values with an Array

### DIFF
--- a/opentoken.js
+++ b/opentoken.js
@@ -59,10 +59,12 @@ OpenTokenAPI.prototype.parseToken = function (token, cb) {
       arr[i] = x.split(/=(.+)?/);
     });
 
+    // Convert/add to the key's value array if multiple exist
     for (index in kvps) {
-      pairs[kvps[index][0]] = kvps[index][1];
+      var key = kvps[index][0], value = kvps[index][1];
+      pairs[key] = key in pairs ? [].concat(pairs[key], value) : value
     }
-    
+
     // Check the minimum required key/value pairs.
     if (!pairs.subject) {
       return cb(new Error("OpenToken missing 'subject'"));
@@ -139,5 +141,3 @@ OpenTokenAPI.prototype.createToken = function (pairs, cb) {
 
 
 exports.OpenTokenAPI = OpenTokenAPI;
-//exports.decode = decode;
-//exports.encode = encode;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opentoken",
+  "name": "@jantaylor/opentoken",
   "version": "1.0.12",
   "description": "OpenToken support for Node.JS",
   "main": "opentoken.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jantaylor/opentoken",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "OpenToken support for Node.JS",
   "main": "opentoken.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "OpenToken support for Node.JS",
   "main": "opentoken.js",
   "scripts": {
-    "test": "clear; node test/opentoken_test.js"
+    "test": "node test/opentoken_test.js && node test/token_test.js"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/73rhodes/node-opentoken.git"
+    "url": "https://github.com/jantaylor/node-opentoken.git"
   },
   "keywords": [
     "authentication",
@@ -17,13 +17,13 @@
   ],
   "author": "Darren DeRidder",
   "contributors": [
-    "Airic Yu <airic.yu@gmail.com>"
+    "Airic Yu <airic.yu@gmail.com>",
+    "Jan Taylor <jantaylor@users.noreply.github.com>"
   ],
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/73rhodes/node-opentoken/issues"
+    "url": "https://github.com/jantaylor/node-opentoken/issues"
   },
-  "homepage": "https://github.com/73rhodes/node-opentoken",
-  "dependencies": {
-  }
+  "homepage": "https://github.com/jantaylor/node-opentoken",
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jantaylor/opentoken",
+  "name": "opentoken",
   "version": "1.1.0",
   "description": "OpenToken support for Node.JS",
   "main": "opentoken.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jantaylor/node-opentoken.git"
+    "url": "https://github.com/73rhodes/node-opentoken.git"
   },
   "keywords": [
     "authentication",
@@ -22,8 +22,8 @@
   ],
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/jantaylor/node-opentoken/issues"
+    "url": "https://github.com/73rhodes/node-opentoken/issues"
   },
-  "homepage": "https://github.com/jantaylor/node-opentoken",
+  "homepage": "https://github.com/73rhodes/node-opentoken",
   "dependencies": {}
 }

--- a/test/opentoken_test.js
+++ b/test/opentoken_test.js
@@ -1,10 +1,11 @@
 var assert = require('assert');
 var token  = require('../lib/token.js');
+var OpenTokenAPI = require('../opentoken.js').OpenTokenAPI;
+
 var yesterday = new Date(Date.now() - (24 * 3600 * 1000));
 var tomorrow  = new Date(Date.now() + (24 * 3600 * 1000));
 var testPassword = "testPassword";
 var cipherId = 2;
-var OpenTokenAPI = require('../opentoken.js').OpenTokenAPI;
 var otkapi = new OpenTokenAPI(cipherId, testPassword);
 
 

--- a/test/token_test.js
+++ b/test/token_test.js
@@ -18,7 +18,7 @@ var cipherId = 2;
   });
 }());
 
-// Test decode (self generated from 3rd part OpenToken lib)
+// Test decode (self generated from 3rd party OpenToken lib)
 !(function () {
   var testToken = "T1RLAQIgGSTfOxeJB3DvBLmtTpeoJv4EuBDlc2cvMEYkYpWOa3Zl6WEMAAAwTJaEPU7Fh4Cud2k9M6XTFNon228y9N_-nFupGIr7tibxVLwkoGZILIb7eUlFEVxn";
   var testData = "subject=foobar\nfizz=buzz\nqux=doo";
@@ -43,7 +43,20 @@ var cipherId = 2;
   });
 }());
 
-// Test Decode w wrong cipherID
+// Test Encode & Decode of array values
+!(function () {
+  var testData = "subject=foo\ngroups=[foo,bar]";
+  otk.encode(testData, cipherId, testPassword, function (err, token) {
+    assert.ifError(err);
+    otk.decode(token, cipherId, testPassword, function (err, data) {
+      process.stdout.write("Test encode/decode of array values... ");
+      assert.equal(data, testData);
+      process.stdout.write("OK\n");
+    });
+  });
+}());
+
+// Test Decode with wrong cipherID
 !(function () {
   var testData = "subject=foobar\nfizz=buzz\nqux=doo";
   otk.encode(testData, cipherId, testPassword, function (err, token) {
@@ -55,23 +68,6 @@ var cipherId = 2;
         process.stdout.write("OK\n");
       } else {
         assert.fail(null, "Error", "Expected an error");
-      }
-    });
-  });
-}());
-
-// try parsing a token earlier than allowed 
-!(function() {
-  var testData = "subject=foobar\nnot-before=" + tomorrow.toISOString();
-  otk.encode(testData, cipherId, testPassword, function (err, token) {
-    assert.ifError(err);
-    otkapi.parseToken(token, function (err, data) {
-      process.stdout.write("Testing token prior to not-before date... ");
-      if (err) {
-        assert.ok( (/Must not use this token before/i).test(err.message) );
-        process.stdout.write("OK\n");
-      } else {
-        assert.fail(data, null, "Expected error 'Must not use this token...'");
       }
     });
   });


### PR DESCRIPTION
The OpenToken RFC encoding allows for Arrays in the payload. However the current implementation of node-opentoken does not.
Currently, an open token is decrypted and it's payload is decoded as multiple lines with `key=value` pairs, which `node-opentoken` converts to a javascript object. 
The issue is: payloads having the same key, will get overwritten by the next line with the same key.
Example: A payload with the same key.

```zsh
# ...
node=boron
node=carbon
# ...
```
Becomes:
```js
{
  // ...
  node: "carbon",
  // ...
}
```

This PR's goal is to allow payload processing of same key values by adding them to an array.

```zsh
# ...
node=boron
node=carbon
# ...
```
Which then becomes:
```js
{
  // ...
  node: ["boron", "carbon"]
  // ...
}
```