### PR TITLE
Remove millisecond precision of ISO 8601 datetime strings

### DIFF
--- a/opentoken.js
+++ b/opentoken.js
@@ -120,9 +120,10 @@ OpenTokenAPI.prototype.createToken = function (pairs, cb) {
     return cb(new Error("OpenToken missing 'subject'"));
   }
 
-  pairs['not-before'] = now.toISOString();
-  pairs['not-on-or-after'] = expiry.toISOString();
-  pairs['renew-until'] = renewUntil.toISOString();
+  // Remove milliseconds
+  pairs['not-before'] = now.toISOString().split('.')[0] + 'Z';
+  pairs['not-on-or-after'] = expiry.toISOString().split('.')[0] + 'Z';
+  pairs['renew-until'] = renewUntil.toISOString().split('.')[0] + 'Z';
 
   // Parse key-value pairs into a string
   var item;

--- a/opentoken.js
+++ b/opentoken.js
@@ -120,7 +120,7 @@ OpenTokenAPI.prototype.createToken = function (pairs, cb) {
     return cb(new Error("OpenToken missing 'subject'"));
   }
 
-  // Remove milliseconds
+  // Format as "yyyy-MM-ddTHH:mm:ssZ" per OpenToken spec
   pairs['not-before'] = now.toISOString().split('.')[0] + 'Z';
   pairs['not-on-or-after'] = expiry.toISOString().split('.')[0] + 'Z';
   pairs['renew-until'] = renewUntil.toISOString().split('.')[0] + 'Z';


### PR DESCRIPTION
To achieve compatibility with the specification, remove milliseconds
from the ISO 8601 datetime strings.
Specifically, set the format of the "not-before", "not-on-or-after", and
"renew-until" to "yyyy-MM-ddTHH:mm:ssZ".

Specification: https://datatracker.ietf.org/doc/html/draft-smith-opentoken-02
Fixes: https://github.com/73rhodes/node-opentoken/issues/2