### PR TITLE
Switch to current Buffer API

### DIFF
--- a/lib/ciphersuites.js
+++ b/lib/ciphersuites.js
@@ -51,7 +51,7 @@ var ciphers = [
 ];
 
 function generateKey(password, salt, cipherId) {
-  salt = salt || new Buffer([0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]);
+  salt = salt || Buffer.from([0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]);
   if (!cipherId || cipherId < 0 || cipherId >= ciphers.length) {
     return null;
   }

--- a/lib/token.js
+++ b/lib/token.js
@@ -78,8 +78,8 @@ function encode(payload, cipherId, password, cb) {
     } else {
       hmac = crypto.createHmac("sha1", encryptionKey);
     }
-    hmac.update(new Buffer([otkVersion]));    // OTK Version
-    hmac.update(new Buffer([cipherId]));      // Cipher Suite
+    hmac.update(Buffer.from([otkVersion]));    // OTK Version
+    hmac.update(Buffer.from([cipherId]));      // Cipher Suite
     if (ivLength > 0) {
       hmac.update(iv);                        // IV Value
     }
@@ -109,21 +109,21 @@ function encode(payload, cipherId, password, cb) {
     // Construct the binary structure representing the OTK; place the MAC
     // IV, key info and cipher-text within the structure
     var otkBuffers = [
-      new Buffer("OTK"),                           // Header literal 'OTK'
-      new Buffer([0x01, cipherId]),                // OTK Version, Cipher Suite
+      Buffer.from("OTK"),                           // Header literal 'OTK'
+      Buffer.from([0x01, cipherId]),                // OTK Version, Cipher Suite
       hmacDigest,                                  // SHA-1 HMAC
-      new Buffer([ivLength])                       // IV length
+      Buffer.from([ivLength])                       // IV length
     ];
     if (ivLength > 0) {
       otkBuffers.push(iv);                         // IV Value
     }
-    otkBuffers.push(new Buffer([keyInfoLength]));  // Key info length (0)
+    otkBuffers.push(Buffer.from([keyInfoLength]));  // Key info length (0)
     // Presently, keyInfoLength is always 0.
     // if (keyInfoLength > 0) {
-    //   otkBuffers.push(new Buffer(keyInfo));        // Key info (never used)
+    //   otkBuffers.push(Buffer.from(keyInfo));        // Key info (never used)
     // }
 
-    var payloadLengthBuffer = new Buffer(2);
+    var payloadLengthBuffer = Buffer.alloc(2);
     payloadLengthBuffer.writeUInt16BE(payloadCipherText.length, 0);
     otkBuffers.push(payloadLengthBuffer);          // Payload length
 
@@ -171,7 +171,7 @@ function decode(otk, cipherId, password, cb) {
   otk = otk.replace(/\*$/, "=");
 
   // Base64 decode the otk
-  var buffer = new Buffer(otk, 'base64');
+  var buffer = Buffer.from(otk, 'base64');
   var index = 0;
   
   // Validate the OTK header literal and version
@@ -245,8 +245,8 @@ function decode(otk, cipherId, password, cb) {
     } else {
       hmacTest = crypto.createHmac("sha1", decryptionKey);
     }
-    hmacTest.update(new Buffer([otkVersion]));    // OTK Version
-    hmacTest.update(new Buffer([otkCipherId]));      // Cipher Suite
+    hmacTest.update(Buffer.from([otkVersion]));    // OTK Version
+    hmacTest.update(Buffer.from([otkCipherId]));      // Cipher Suite
     if (iv) {
       hmacTest.update(iv);                        // IV Value
     }


### PR DESCRIPTION
The currently used Buffer API is deprecated:
https://nodejs.org/gl/docs/guides/buffer-constructor-deprecation/

This change updates the code to use the current Buffer API.